### PR TITLE
Fixed Menu Container select field bug

### DIFF
--- a/fz-acf-nav-menu.php
+++ b/fz-acf-nav-menu.php
@@ -3,7 +3,7 @@
  * Plugin Name: Advanced Custom Fields: Nav Menu Field
  * Plugin URI: http://faisonz.com/wordpress-plugins/advanced-custom-fields-nav-menu-field/
  * Description: Add-On plugin for Advanced Custom Fields (ACF) that adds a 'Nav Menu' Field type.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: Faison Zutavern
  * Author URI: http://faisonz.com
  * License: GPL2 or later

--- a/fz-acf-nav-menu.php
+++ b/fz-acf-nav-menu.php
@@ -1,67 +1,46 @@
 <?php
 /*
-Plugin Name: Advanced Custom Fields: Nav Menu Field
-Plugin URI: https://github.com/jgraup/advanced-custom-fields-nav-menu-field
-Original Plugin URI: http://wordpress.org/plugins/advanced-custom-fields-nav-menu-field/
-Description: Add-On plugin for Advanced Custom Fields (ACF) that adds a 'Nav Menu' Field type.
-Version: 1.1.2.5
-Author: Faison Zutavern and ACF 5 PRO port by Jesse Graupmann
-Author URI: https://github.com/jgraup/advanced-custom-fields-nav-menu-field
-Original Author URI: http://faisonz.com/
-License: GPL2 or later
-*/
+ * Plugin Name: Advanced Custom Fields: Nav Menu Field
+ * Plugin URI: http://faisonz.com/wordpress-plugins/advanced-custom-fields-nav-menu-field/
+ * Description: Add-On plugin for Advanced Custom Fields (ACF) that adds a 'Nav Menu' Field type.
+ * Version: 2.0.0
+ * Author: Faison Zutavern
+ * Author URI: http://faisonz.com
+ * License: GPL2 or later
+ */
 
-class acf_field_nav_menu_plugin
-{
-	/*
-	*  Construct
-	*
-	*  @description: 
-	*  @since: 3.6
-	*  @created: 1/04/13
-	*/
-	
-	function __construct()
-	{
-		// set text domain
-		/*
-		$domain = 'acf-nav_menu';
-		$mofile = trailingslashit(dirname(__File__)) . 'lang/' . $domain . '-' . get_locale() . '.mo';
-		load_textdomain( $domain, $mofile );
-		*/
-		 
-		// version 4+
-		add_action('acf/register_fields', array($this, 'register_fields'));	
-
-		// version 5+
-		add_action('acf/include_field_types', array($this, 'include_field_types'));	
-	}
-	
-	/*
-	*  register_fields
-	*
-	*  @description: 
-	*  @since: 3.6
-	*  @created: 1/04/13
-	*/
-	
-	function register_fields()
-	{
-		include_once('nav-menu-v4.php');
-	}
-
-	/*
-	*  register_fields
-	*
-	*  @description: 
-	*  @since: 3.6
-	*  @created: 8/27/14
-	*/
-	
-	function include_field_types()
-	{
-		include_once('nav-menu-v5.php');
-	}
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-new acf_field_nav_menu_plugin();
+class ACF_Nav_Menu_Field_Plugin {
+
+	/**
+	 * Adds register hooks for the Nav Menu Field.
+	 */
+	public function __construct() {
+		// version 4
+		add_action( 'acf/register_fields', array( $this, 'register_field_v4' ) );	
+
+		// version 5
+		add_action( 'acf/include_field_types', array( $this, 'register_field_v5' ) );
+	}
+
+	/**
+	 * Loads up the Nav Menu Field for ACF v4
+	 */
+	public function register_field_v4() {
+		include_once 'nav-menu-v4.php';
+	}
+
+	/**
+	 * Loads up the Nav Menu Field for ACF v5
+	 */
+	public function register_field_v5() {
+		include_once 'nav-menu-v5.php';
+	}
+	
+}
+
+new ACF_Nav_Menu_Field_Plugin();

--- a/nav-menu-v4.php
+++ b/nav-menu-v4.php
@@ -1,235 +1,219 @@
 <?php
+/**
+* Nav Menu Field v4
+*
+* @package ACF Nav Menu Field
+*/
 
-class acf_field_nav_menu extends acf_field
-{
-	// vars
-	var $settings, // will hold info such as dir / path
-		$defaults; // will hold default field options
-		
-	/*
-	*  __construct
-	*
-	*  Set name / label needed for actions / filters
-	*
-	*  @since	3.6
-	*  @date	23/01/13
-	*/
-	
-	function __construct()
-	{
-		// vars
-		$this->name = 'nav_menu';
-		$this->label = __('Nav Menu');
-		$this->category = __("Relational",'acf'); // Basic, Content, Choice, etc
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * ACF_Field_Nav_Menu_V4 Class
+ *
+ * This class contains all the custom workings for the Nav Menu Field for ACF v4
+ */
+class ACF_Field_Nav_Menu_V4 extends acf_field {
+
+	/**
+	 * Sets up some default values and delegats work to the parent constructor.
+	 */
+	public function __construct() {
+		$this->name     = 'nav_menu';
+		$this->label    = __( 'Nav Menu' );
+		$this->category = __( 'Relational' ); // Basic, Content, Choice, etc
 		$this->defaults = array(
 			'save_format' => 'id',
-			'allow_null' => 0,
-			'container' => 'div'
+			'allow_null'  => 0,
+			'container'   => 'div',
 		);
-		
-		// do not delete!
-    	parent::__construct();
-    	
-    	// settings
-		$this->settings = array(
-			'path' => apply_filters('acf/helpers/get_path', __FILE__),
-			'dir' => apply_filters('acf/helpers/get_dir', __FILE__),
-			'version' => '1.1.2'
-		);
+
+		parent::__construct();
 	}
-	
-	/*
-	*  create_options()
-	*
-	*  Create extra options for your field. This is rendered when editing a field.
-	*  The value of $field['name'] can be used (like bellow) to save extra data to the $field
-	*
-	*  @type	action
-	*  @since	3.6
-	*  @date	23/01/13
-	*
-	*  @param	$field	- an array holding all the field's data
-	*/
-	
-	function create_options( $field )
-	{
-		// defaults?
-		$field = array_merge($this->defaults, $field);
-		
-		// key is needed in the field names to correctly save the data
-		$key = $field['name'];
-		
-		
+
+	/**
+	 * Renders the Nav Menu Field options seen when editing a Nav Menu Field.
+	 *
+	 * @param array $field The array representation of the current Nav Menu Field.
+	 */
+	public function create_options( $field ) {
+		$field = array_merge( $this->defaults, $field );
+		$key   = $field['name'];
+
 		// Create Field Options HTML
 		?>
-<tr class="field_option field_option_<?php echo $this->name; ?>">
-	<td class="label">
-		<label><?php _e("Return Value",'acf'); ?></label>
-	</td>
-	<td>
-		<?php
-		
-		do_action('acf/create_field', array(
-			'type'		=>	'radio',
-			'name'		=>	'fields['.$key.'][save_format]',
-			'value'		=>	$field['save_format'],
-			'layout'	=>	'horizontal',
-			'choices' 	=>	array(
-				'object'	=>	__("Nav Menu Object",'acf'),
-				'menu'		=>	__("Nav Menu HTML",'acf'),
-				'id'		=>	__("Nav Menu ID",'acf')
-			)
-		));
-		
-		?>
-	</td>
-</tr>
-<tr class="field_option field_option_<?php echo $this->name; ?>">
-	<td class="label">
-		<label><?php _e("Menu Container",'acf'); ?></label>
-		<p class="description">What to wrap the Menu's ul with.<br />Only used when returning HTML.</p>
-	</td>
-	<td>
-		<?php
-
-		$choices = $this->get_allowed_nav_container_tags();
-		
-		do_action('acf/create_field', array(
-			'type'		=>	'select',
-			'name'		=>	'fields['.$key.'][container]',
-			'value'		=>	$field['container'],
-			'choices' 	=>	$choices
-		));
-		
-		?>
-	</td>
-</tr>
-<tr class="field_option field_option_<?php echo $this->name; ?>">
-	<td class="label">
-		<label><?php _e("Allow Null?",'acf'); ?></label>
-	</td>
-	<td>
-		<?php 
-		do_action('acf/create_field', array(
-			'type'	=>	'radio',
-			'name'	=>	'fields['.$key.'][allow_null]',
-			'value'	=>	$field['allow_null'],
-			'choices'	=>	array(
-				1	=>	__("Yes",'acf'),
-				0	=>	__("No",'acf'),
-			),
-			'layout'	=>	'horizontal',
-		));
-		?>
-	</td>
-</tr>
+		<tr class="field_option field_option_<?php echo esc_attr( $this->name ); ?>">
+			<td class="label">
+				<label><?php _e( 'Return Value' ); ?></label>
+			</td>
+			<td>
+			<?php
+				do_action('acf/create_field', array(
+					'type'    => 'radio',
+					'name'    => 'fields['.$key.'][save_format]',
+					'value'   => $field['save_format'],
+					'layout'  => 'horizontal',
+					'choices' => array(
+						'object' => __( 'Nav Menu Object' ),
+						'menu'   => __( 'Nav Menu HTML' ),
+						'id'     => __( 'Nav Menu ID' ),
+					),
+				) );
+			?>
+			</td>
+		</tr>
+		<tr class="field_option field_option_<?php echo esc_attr( $this->name ); ?>">
+			<td class="label">
+				<label><?php _e( 'Menu Container' ); ?></label>
+				<p class="description"><?php _e( "What to wrap the Menu's ul with (when returning HTML only)" ) ?></p>
+			</td>
+			<td>
+			<?php
+				do_action('acf/create_field', array(
+					'type'         => 'radio',
+					'layout'       => 'horizontal',
+					'name'    => 'fields['.$key.'][container]',
+					'value'   => $field['container'],
+					'choices' => $this->get_allowed_nav_container_tags(),
+				) );
+			?>
+			</td>
+		</tr>
+		<tr class="field_option field_option_<?php echo esc_attr( $this->name ); ?>">
+			<td class="label">
+				<label><?php _e( 'Allow Null?' ); ?></label>
+			</td>
+			<td>
+			<?php
+				do_action('acf/create_field', array(
+					'type'    => 'radio',
+					'name'    => 'fields['.$key.'][allow_null]',
+					'value'   => $field['allow_null'],
+					'layout'  => 'horizontal',
+					'choices' => array(
+						1 => __( 'Yes' ),
+						0 => __( 'No' ),
+					),
+				) );
+			?>
+			</td>
+		</tr>
 		<?php
 	}
-	
-	/*
-	*  create_field()
-	*
-	*  Create the HTML interface for your field
-	*
-	*  @param	$field - an array holding all the field's data
-	*
-	*  @type	action
-	*  @since	3.6
-	*  @date	23/01/13
-	*/
-	
-	function create_field( $field )
-	{
-		// defaults?
-		/*
-		$field = array_merge($this->defaults, $field);
-		*/
-				
-		// create Field HTML
-		echo sprintf( '<select id="%d" class="%s" name="%s">', $field['id'], $field['class'], $field['name']  );
 
-		// null
-		if( $field['allow_null'] )
-		{
-			echo '<option value=""> - Select - </option>';
+	/**
+	 * Renders the Nav Menu Field.
+	 *
+	 * @param array $field The array representation of the current Nav Menu Field.
+	 */
+	public function create_field( $field ) {
+		$allow_null = $field['allow_null'];
+		$nav_menus  = $this->get_nav_menus( $allow_null );
+
+		if ( empty( $nav_menus ) ) {
+			return;
 		}
-
-		// Nav Menus
-		$nav_menus = $this->get_nav_menus();
-
-		foreach( $nav_menus as $nav_menu_id => $nav_menu_name ) {
-			$selected = selected( $field['value'], $nav_menu_id );
-			echo sprintf( '<option value="%1$d" %3$s>%2$s</option>', $nav_menu_id, $nav_menu_name, $selected );
-		}
-
-		echo '</select>';
+		?>
+		<select id="<?php esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>">
+		<?php foreach( $nav_menus as $nav_menu_id => $nav_menu_name ) : ?>
+			<option value="<?php echo esc_attr( $nav_menu_id ); ?>" <?php selected( $field['value'], $nav_menu_id ); ?>>
+				<?php echo esc_html( $nav_menu_name ); ?>
+			</option>
+		<?php endforeach; ?>
+		</select>
+		<?php
 	}
 
-	function get_nav_menus() {
-		$navs = get_terms('nav_menu', array( 'hide_empty' => false ) );
-		
+	/**
+	 * Gets a list of Nav Menus indexed by their Nav Menu IDs.
+	 *
+	 * @param bool $allow_null If true, prepends the null option.
+	 *
+	 * @return array An array of Nav Menus indexed by their Nav Menu IDs.
+	 */
+	private function get_nav_menus( $allow_null = false ) {
+		$navs = get_terms( 'nav_menu', array( 'hide_empty' => false ) );
+
 		$nav_menus = array();
-		foreach( $navs as $nav ) {
+
+		if ( $allow_null ) {
+			$nav_menus[''] = ' - Select - ';
+		}
+
+		foreach ( $navs as $nav ) {
 			$nav_menus[ $nav->term_id ] = $nav->name;
 		}
 
 		return $nav_menus;
 	}
 
-	function get_allowed_nav_container_tags() {
-		$tags = apply_filters( 'wp_nav_menu_container_allowedtags', array( 'div', 'nav' ) );
+	/**
+	 * Get the allowed wrapper tags for use with wp_nav_menu().
+	 *
+	 * @return array An array of allowed wrapper tags.
+	 */
+	private function get_allowed_nav_container_tags() {
+		$tags           = apply_filters( 'wp_nav_menu_container_allowedtags', array( 'div', 'nav' ) );
 		$formatted_tags = array(
-			array( '0' => 'None' )
+			'0' => 'None',
 		);
-		foreach( $tags as $tag ) {
-    		$formatted_tags[0][$tag] = ucfirst( $tag );
+
+		foreach ( $tags as $tag ) {
+			$formatted_tags[$tag] = ucfirst( $tag );
 		}
+
 		return $formatted_tags;
 	}
-	
-	function format_value_for_api( $value, $post_id, $field )
-	{
-		// defaults
+
+	/**
+	 * Renders the Nav Menu Field.
+	 *
+	 * @param int   $value   The Nav Menu ID selected for this Nav Menu Field.
+	 * @param int   $post_id The Post ID this $value is associated with.
+	 * @param array $field   The array representation of the current Nav Menu Field.
+	 *
+	 * @return mixed The Nav Menu ID, or the Nav Menu HTML, or the Nav Menu Object, or false.
+	 */
+	public function format_value_for_api( $value, $post_id, $field ) {
 		$field = array_merge($this->defaults, $field);
 		
-		if( !$value ) {
+		if( empty( $value ) ) {
 			return false;
 		}
 
 		// check format
-		if( $field['save_format'] == 'object' ) {
+		if( 'object' == $field['save_format'] ) {
 			$wp_menu_object = wp_get_nav_menu_object( $value );
 
-			if( !$wp_menu_object ) {
+			if( empty( $wp_menu_object ) ) {
 				return false;
 			}
 
 			$menu_object = new stdClass;
 
-			$menu_object->ID = $wp_menu_object->term_id;
-			$menu_object->name = $wp_menu_object->name;
-			$menu_object->slug = $wp_menu_object->slug;
+			$menu_object->ID    = $wp_menu_object->term_id;
+			$menu_object->name  = $wp_menu_object->name;
+			$menu_object->slug  = $wp_menu_object->slug;
 			$menu_object->count = $wp_menu_object->count;
 
 			return $menu_object;
 
-		} elseif( $field['save_format'] == 'menu' ) {
-			
+		} elseif( 'menu' == $field['save_format'] ) {
 			ob_start();
 
 			wp_nav_menu( array(
 				'menu' => $value,
 				'container' => $field['container']
 			) );
-			
-			return ob_get_clean();
 
+			return ob_get_clean();
 		}
-		
+
+		// Just return the Nav Menu ID
 		return $value;
 	}
 }
 
-// create field
-new acf_field_nav_menu(); 
-?>
+new ACF_Field_Nav_Menu_V4();

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Author: Faison Zutavern
 Author URI: http://faisonz.com
 Requires at least: 3.4
 Tested up to: 4.0
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPL2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,6 +81,9 @@ First, check that you added the necessary ACF code to your templates. If you don
 
 == Changelog ==
 
+= 2.0.1 =
+* Changed Menu Container field to radio select.
+
 = 2.0.0 =
 * Added ACF v5 class.
 * Updated code to follow coding standards
@@ -99,6 +102,9 @@ First, check that you added the necessary ACF code to your templates. If you don
 * Initial Release.
 
 == Upgrade Notice ==
+
+= 2.0.0 =
+Fixed issue with selecting the Menu's containing element.
 
 = 2.0.0 =
 You now have support for ACF v5, and when the code is read, it makes fewer people cry!

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Author: Faison Zutavern
 Author URI: http://faisonz.com
 Requires at least: 3.4
 Tested up to: 4.0
-Stable tag: 1.1.2.5
+Stable tag: 2.0.0
 License: GPL2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,7 +13,7 @@ Add-On plugin for Advanced Custom Fields (ACF) that adds a 'Nav Menu' Field type
 
 == Description ==
 
-Add [Navigation Menus](http://codex.wordpress.org/Navigation_Menus) to [Advanced Custom Fields](http://wordpress.org/extend/plugins/advanced-custom-fields/) (ACF) with the Nav Menu Field plugin! This plugin adds the Nav Menu Field type to ACF (version 4 and up), allowing you to select from the menus you create in the WordPress Admin backend to use on your website's frontend.
+Add [Navigation Menus](http://codex.wordpress.org/Navigation_Menus) to [Advanced Custom Fields](http://wordpress.org/extend/plugins/advanced-custom-fields/) (ACF) with the Nav Menu Field plugin! This plugin adds the Nav Menu Field type to ACF (version 5 & 4), allowing you to select from the menus you create in the WordPress Admin backend to use on your website's frontend.
 
 Using ACF, you can set the Nav Menu Field to return the selected menu's:
 
@@ -29,28 +29,12 @@ Feel free to try this add-on on your dev site, ask questions on the support link
 
 This add-on will work with:
 
-* version 4 and up
+* version 5
+* version 4
 
 == Installation ==
 
-This add-on can be treated as both a WP plugin and a theme include.
-
-= Plugin =
-1. Copy the 'advanced-custom-fields-nav-menu-field' folder into your plugins folder
-2. Activate the plugin via the Plugins admin page
-
-= Include =
-1.	Copy the 'advanced-custom-fields-nav-menu-field' folder into your theme folder (can use sub folders). You can place the folder anywhere inside the 'wp-content' directory
-2.	Edit your functions.php file and add the code below (Make sure the path is correct to include the nav-menu-v4.php file)
-
-`
-add_action('acf/register_fields', 'my_register_fields');
-
-function my_register_fields()
-{
-	include_once('advanced-custom-fields-nav-menu-field/nav-menu-v4.php');
-}
-`
+Follow the following instructions: https://codex.wordpress.org/Managing_Plugins#Installing_Plugins
 
 == Frequently Asked Questions ==
 
@@ -75,11 +59,11 @@ Finally, create or edit a page, select a menu in the Side Menu field, and view t
 
 = Will you make this plugin compatible with Advanced Custom Fields v3? =
 
-I will do that soon, but you really should think about upgrading Advanced Custom Fields. ACF has seen a lot of great changes from v3 to the most current version.
+No.
 
 = Why does the Nav Menu returned by your plugin look like an unstyled list of links? =
 
-I decided to return the Nav Menus without any added style, because I don't know what your website looks like. Frankly, I find it annoying when I have to compete with a plugin's styles, especially when a lot of them use !important. Now I can use this plugin on many sites with only a little extra styling work ahead of me.
+So that you can style it yourself. I don't want to step on your toes :)
 
 = I added the Nav Menu Field to Pages, selected my menu when creating a new page, but the menu doesn't show. What gives? =
 
@@ -97,9 +81,10 @@ First, check that you added the necessary ACF code to your templates. If you don
 
 == Changelog ==
 
-= 1.1.2.5 =
-* Adding support for ACF Pro v5
-* Tested and works with WordPress 4.0
+= 2.0.0 =
+* Added ACF v5 class.
+* Updated code to follow coding standards
+* Updated the ACF v4 class to use the updated code found in the ACF v5 Class
 
 = 1.1.2 =
 * Fixed a silly mistake related to allowing Null for a Nav Menu Field. Basically, it was storing the string "null" when you don't select a menu, that's taken care of now.
@@ -114,6 +99,9 @@ First, check that you added the necessary ACF code to your templates. If you don
 * Initial Release.
 
 == Upgrade Notice ==
+
+= 2.0.0 =
+You now have support for ACF v5, and when the code is read, it makes fewer people cry!
 
 = 1.1.1 =
 I forgot to add a default value for the Menu Container field. So to eliminate WP_DEBUG warnings, I added 'div' as the default value. Please upgrade to avoid the warnings.


### PR DESCRIPTION
- Updated code to match v. 2.0 hosted on WordPress.org & incremented plugin to v. 2.0.1
- Changed Menu Container select box in ACF 4 & ACF 5 to radio checkbox. This fixes issue where saving always reverts menu container back to Nav.
