### PR TITLE
Adding Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "jgraup/acf-nav-menu-field",
+    "description": "Advanced Custom Fields plugin: Nav Menu Field",
+    "keywords": ["wordpress", "plugin"],
+    "type": "wordpress-plugin",
+    "homepage": "https://github.com/jgraup/advanced-custom-fields-nav-menu-field",
+    "authors": [
+        {
+            "name": "Faison Zutavern",
+            "homepage": "https://github.com/jgraup/advanced-custom-fields-nav-menu-field",
+            "role": "author"
+        },
+        {
+            "name": "Jesse Graupmann",
+            "homepage": "https://github.com/jgraup/advanced-custom-fields-nav-menu-field",
+            "role": "port to ACF 5 PRO"
+        }
+     ],
+    "license": "GPL2 or later",
+    "require": {
+    "composer/installers": "v1.0.7"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jgraup/acf-nav-menu-field",
-    "description": "Advanced Custom Fields plugin: Nav Menu Field",
+    "description": "Add-On plugin for Advanced Custom Fields (ACF) that adds a 'Nav Menu' Field type.",
     "keywords": ["wordpress", "plugin"],
     "type": "wordpress-plugin",
     "homepage": "https://github.com/jgraup/advanced-custom-fields-nav-menu-field",


### PR DESCRIPTION
Would like to add basic composer support for this plugin. Composer is dependency manager. It is easy to use, all dependency are defined in a single place and consistent across team and servers. Having Composer support does not influence work of original plugin in any way.

For more info on Composer and Wordpress: https://roots.io/using-composer-with-wordpress/